### PR TITLE
update rust types

### DIFF
--- a/src/conv_rust.rs
+++ b/src/conv_rust.rs
@@ -144,7 +144,8 @@ fn fmt_field<'a>(field: &Field<'a, Rust>, f: &mut Formatter, as_accessor: bool) 
         if expr.arr.is_arr() && expr.arr.is_null() || !expr.arr.is_arr() && expr.null {
             writeln!(f, "    #[serde(skip_serializing_if = \"Option::is_none\")]")?;
         }
-        write!(f, "    pub {}: {},", field.name, field.expr)?;
+
+        write!(f, "    pub {}: {},", escape_keyword(field.name), field.expr)?;
     }
     Ok(())
 }
@@ -203,5 +204,45 @@ impl<'a> Display for Union<'a, Rust> {
             writeln!(f, "    {}({}),", name, name)?;
         }
         writeln!(f, "}}")
+    }
+}
+
+fn escape_keyword<'a>(identifier: &'a str) -> &'a str {
+    match identifier {
+        "as" => "r#as",
+        "break" => "r#break",
+        "const" => "r#const",
+        "continue" => "r#continue",
+        "crate" => "r#crate",
+        "else" => "r#else",
+        "enum" => "r#enum",
+        "extern" => "r#extern",
+        "false" => "r#false",
+        "fn" => "r#fn",
+        "for" => "r#for",
+        "if" => "r#if",
+        "impl" => "r#impl",
+        "in" => "r#in",
+        "let" => "r#let",
+        "loop" => "r#loop",
+        "match" => "r#match",
+        "mod" => "r#mod",
+        "move" => "r#move",
+        "mut" => "r#mut",
+        "pub" => "r#pub",
+        "ref" => "r#ref",
+        "return" => "r#return",
+        "self" => "r#self",
+        "static" => "r#static",
+        "struct" => "r#struct",
+        "super" => "r#super",
+        "trait" => "r#trait",
+        "true" => "r#true",
+        "type" => "r#type",
+        "unsafe" => "r#unsafe",
+        "use" => "r#use",
+        "where" => "r#where",
+        "while" => "r#while",
+        _ => identifier,
     }
 }

--- a/src/conv_rust.rs
+++ b/src/conv_rust.rs
@@ -18,7 +18,7 @@ fn translate_typ(typ: &str) -> &str {
         "String" => "String",
         "Boolean" => "bool",
         "ID" => "ID",
-        "Date" => "Date<Utc>",
+        "Date" => "DateTime<Utc>",
         "BigInt" => "i64",
         _ => typ,
     }
@@ -31,7 +31,7 @@ impl<'a> Display for Ast<'a, Rust> {
         writeln!(f, "use serde::{{Deserialize, Serialize}};\n")?;
 
         if self.has_type(|t| t.typ == "Date") {
-            writeln!(f, "use chrono::{{Date, Utc}};\n")?;
+            writeln!(f, "use chrono::{{DateTime, Utc}};\n")?;
         }
         if self.has_type(|t| t.typ == "ID") {
             writeln!(f, "pub type ID = String;\n")?;


### PR DESCRIPTION
- rust: escape 'type' field name
- rust: use DateTime instead of chrono::Date (deprecated)
