### PR TITLE
Add Foundation import to `conv_swift.rs`

### DIFF
--- a/src/conv_swift.rs
+++ b/src/conv_swift.rs
@@ -26,6 +26,7 @@ fn translate_typ(typ: &str) -> &str {
 
 impl<'a> Display for Ast<'a, Swift> {
     fn fmt(&self, f: &mut Formatter) -> Result {
+        writeln!(f, "import Foundation")?;
         if self.has_type(|t| t.typ == "ID") {
             writeln!(f, "typealias ID = String;\n")?;
         }


### PR DESCRIPTION
This is needed in the iOS app to avoid errors in the test suite. 