### PR TITLE
Fix display for union types (edit: WIP, don't merge yet)

### DIFF
--- a/src/conv_kotlin.rs
+++ b/src/conv_kotlin.rs
@@ -154,11 +154,12 @@ impl<'a> Display for Union<'a, Kotlin> {
             }
             writeln!(
                 f,
-                "    class {}{}(val {}: {}) : {}",
+                "    class {}{}(val {}: {}) : {}()",
                 self.name, name, lcased, name, self.name
             )?;
             lcaseds.push((name, lcased));
         }
+        writeln!(f, "}}")?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR modifies `impl Display for Union` in `src/conv_kotlin.rs`, by:
 - adding a missing closing bracket
 - making sure constructors are called correctly
 
 So instead of:
 ```
 sealed class TaskStepOption {
    class TaskStepOptionTaskStepOptionSingleSelect(val taskStepOptionSingleSelect: TaskStepOptionSingleSelect) : TaskStepOption
    class TaskStepOptionTaskStepOptionMultiSelect(val taskStepOptionMultiSelect: TaskStepOptionMultiSelect) : TaskStepOption
```

We get:
```
sealed class TaskStepOption {
    class TaskStepOptionTaskStepOptionSingleSelect(val taskStepOptionSingleSelect: TaskStepOptionSingleSelect) : TaskStepOption()
    class TaskStepOptionTaskStepOptionMultiSelect(val taskStepOptionMultiSelect: TaskStepOptionMultiSelect) : TaskStepOption()
}
```