### PR TITLE
Exclude Rust files from compilation for doc tests

### DIFF
--- a/src/conv_rust/mod.rs
+++ b/src/conv_rust/mod.rs
@@ -39,6 +39,7 @@ impl<'a> Display for Ast<'a, Rust> {
 
         writeln!(f, "#![allow(non_snake_case)]")?;
         writeln!(f, "#![allow(non_camel_case_types)]\n")?;
+        writeln!(f, "#![cfg(not(doctest))]\n")?;
         writeln!(f, "use serde::{{Deserialize, Serialize}};\n")?;
 
         let has_non_null_dates =


### PR DESCRIPTION
The GraphQL schema contains triple backticks which Rust will try to
interpret as Rust code during compilation of doc tests and this will
obviously fail.
